### PR TITLE
Issue 49: Add Dark mode support for OSS Licenses Webview.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "androidx.annotation:annotation:1.5.0"
     implementation 'androidx.preference:preference:1.2.0'
+    implementation 'androidx.webkit:webkit:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
This PR introduces dark mode support for Open source license dialog.

Code changes: 
Using WebSettingsCompat.setForceDark  (deprecated) for backward compatibility as this app has minimum sdk support as 23. It can be removed once minimum target is set to 29. 

Changes are tested with android 10/11 emulator and android 11 physical device.
Please find attached testing video. Video quality was reduced because off size limitations.

https://user-images.githubusercontent.com/15320190/198994842-e60eaf37-9ddc-4d01-915a-b9fa5541c958.mov

